### PR TITLE
ErrorList lexer fixes

### DIFF
--- a/lexers/LexErrorList.cxx
+++ b/lexers/LexErrorList.cxx
@@ -92,9 +92,12 @@ int RecogniseErrorListLine(const char *lineBuffer, Sci_PositionU lengthLine, Sci
 		} else {
 			return SCE_ERR_DIFF_ADDITION;
 		}
-	} else if (lineBuffer[0] == '-') {
+	} else if (lineBuffer[0] == '-' && !strstart(lineBuffer, "-r")) {
 		if (strstart(lineBuffer, "--- ")) {
 			return SCE_ERR_DIFF_MESSAGE;
+		} else if (strstart(lineBuffer, "-- ")) {
+			// CMake status messages
+			return SCE_ERR_DEFAULT;
 		} else {
 			return SCE_ERR_DIFF_DELETION;
 		}


### PR DESCRIPTION
- Better handling of `CMake` status messages

With the current handling, lines starting with `-` are considered "Diff deleted" message except for lines starting with `---` which are considered as "Diff message". A common pattern are the status line generated by `CMake`. These lines are starting with `--`. This fix handles them as "normal" lines and not has "Diff deleted" lines

- Better handling for the `ls -l` output

A common output for the `ls -l` command are lines with a similar pattern to:
```bash
-rw-r--r--  1 user user   80864 Nov  4 23:35 file.cpp
```

These lines are mistakenly considered as "Diff deleted" lines (due to the `-` at the start) - this commit fixes this behavior